### PR TITLE
（再次）修复 Linux 下崩溃问题

### DIFF
--- a/src/ui/roomscene.cpp
+++ b/src/ui/roomscene.cpp
@@ -3111,8 +3111,10 @@ void RoomScene::freeze(){
     chat_edit->setEnabled(false);
 
 #ifdef AUDIO_SUPPORT
+#ifdef  Q_OS_WIN32
     if(BackgroundMusic)
         BackgroundMusic->stop();
+#endif
 #endif
 
     progress_bar->hide();


### PR DESCRIPTION
之前的代码没有把背景音乐禁光，还是会有崩溃，这下好了。崩溃好像是 phonon 的 Bug，有时间再研究。
