### PR TITLE
fix a logic error when judge who has the final retrial

### DIFF
--- a/lua/ai/smart-ai.lua
+++ b/lua/ai/smart-ai.lua
@@ -2643,13 +2643,14 @@ function SmartAI:getFinalRetrial(player)
 	local maxenemyseat = -1
 	local tmpfriend
 	local tmpenemy
-	for _, aplayer in ipairs(self:getFriends(player)) do
+	player = player or self.room:getCurrent()
+	for _, aplayer in ipairs(self:getFriends(self.player)) do
 		if self:hasSkills(sgs.wizard_harm_skill, aplayer) and self:canRetrial(aplayer) then
 			tmpfriend = (aplayer:getSeat() - player:getSeat()) % (global_room:alivePlayerCount())
 			if tmpfriend > maxfriendseat then maxfriendseat = tmpfriend end
 		end
 	end
-	for _, aplayer in ipairs(self:getEnemies(player)) do
+	for _, aplayer in ipairs(self:getEnemies(self.player)) do
 		if self:hasSkills(sgs.wizard_harm_skill, aplayer) and self:canRetrial(aplayer) then
 			tmpenemy = (aplayer:getSeat() - player:getSeat()) % (global_room:alivePlayerCount())
 			if tmpenemy > maxenemyseat then maxenemyseat = tmpenemy end
@@ -2667,9 +2668,9 @@ end
 function SmartAI:getRetrialCardId(cards, judge)
 	local can_use = {}
 	for _, card in ipairs(cards) do
-		if self:isFriend(judge.who) and judge:isGood(card) and not (self:getFinalRetrial(judge.who) == 2 and card:inherits("Peach")) then
+		if self:isFriend(judge.who) and judge:isGood(card) and not (self:getFinalRetrial() == 2 and card:inherits("Peach")) then
 			table.insert(can_use, card)
-		elseif self:isEnemy(judge.who) and not judge:isGood(card) and not (self:getFinalRetrial(judge.who) == 2 and card:inherits("Peach")) then
+		elseif self:isEnemy(judge.who) and not judge:isGood(card) and not (self:getFinalRetrial() == 2 and card:inherits("Peach")) then
 			table.insert(can_use, card)
 		end
 	end

--- a/lua/ai/standard_cards-ai.lua
+++ b/lua/ai/standard_cards-ai.lua
@@ -560,14 +560,10 @@ end
 
 function sgs.ai_armor_value.eight_diagram(player, self)
 	local haszj = self:hasSkills("leiji", self:getEnemies(player))
-	if haszj and self:getFinalRetrial(player) == 2 then 
+	if haszj then 
 		return 2
 	end
-	if (not haszj and self:getFinalRetrial(player) == 2) or
-		(haszj and self:getFinalRetrial(player) == 1) then
-		return 3
-	end
-	if self:getFinalRetrial(player) == 1 or player:hasSkill("tiandu") then 
+	if player:hasSkill("tiandu") then 
 		return 5
 	end
 	return 4 


### PR DESCRIPTION
重新修复此问题。
getFinalRetrial不传参时player为当前处于play状态的玩家，其他传参场合保证judge.who就是当前活动角色（延时锦囊相关）

player改self.player是因为要从调用这个函数的角色的角度来划分朋友和敌人
