### PR TITLE
Close ask_dialog and delete it in after exec()

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -868,8 +868,7 @@ void Client::chooseCard(int card_id){
     if(card_id == -2){
         request("chooseCard .");
     }else{
-        delete ask_dialog;
-        ask_dialog = NULL;
+        ask_dialog->accept();
 
         request(QString("chooseCard %1").arg(card_id));
     }

--- a/src/ui/roomscene.cpp
+++ b/src/ui/roomscene.cpp
@@ -2109,6 +2109,8 @@ void RoomScene::updateStatus(Client::Status status){
             if(ClientInstance->ask_dialog != NULL){
                 ClientInstance->ask_dialog->setParent(main_window, Qt::Dialog);
                 ClientInstance->ask_dialog->exec();
+                delete ClientInstance->ask_dialog;
+                ClientInstance->ask_dialog = NULL;
 
                 ok_button->setEnabled(false);
                 cancel_button->setEnabled(true);


### PR DESCRIPTION
Fixed Moligaloo/QSanguosha#197.

This patch makes sure that `ask_dialog` is freed every time **after** exec(), so that event loop during `ask_dialog->exec()` would not observe freed `ask_dialog` which causes crash.

Two occurrences of `delete ask_dialog` in `Client::askForSuit` and `Client::askForKingdom` should be audited as well.
